### PR TITLE
B2xx gpio tx rx switch

### DIFF
--- a/src/B200Control.cxx
+++ b/src/B200Control.cxx
@@ -41,43 +41,108 @@
 #include <time.h>
 
 #include <strings.h>
+#include <iostream>
 
+//new
+#include "PropTree.hxx"
+#include <uhd/property_tree.hpp>
 
 namespace SoDa 
 {
   B200Control::B200Control(uhd::usrp::multi_usrp::sptr _usrp, int _mboard) : TRControl() {
     usrp = _usrp;
     mboard = _mboard; 
+  
+    //new
+    PropTree tree(usrp, "TRControl");
+    B200Control::modelname = tree.getStringProp("name", "unknown");
+    if ((modelname == std::string("B200")) ) {
+        B200_type = SoDa_B200_type_t::eB200;};
+    if ((modelname == std::string("B210")) ) {
+        B200Control::B200_type = SoDa_B200_type_t::eB210;};
+    if ((modelname == std::string("B200mini")) ) {
+        B200Control::B200_type = SoDa_B200_type_t::eB200mini;};
+    if ((modelname == std::string("B200mini-i")) ) {
+        B200Control::B200_type = SoDa_B200_type_t::eB200mini_i;};
+    if ((modelname == std::string("B205mini-i")) ) {
+        B200Control::B200_type = SoDa_B200_type_t::eB205mini_i;};
 
+    // new debug
     std::vector<std::string> port = usrp->get_gpio_banks(0); 
+    std::cerr << "port list :" << port[0] << std::endl;  
+      
+    switch(B200Control::B200_type) {
+      case SoDa_B200_type_t::eB200mini : 
+        // GPIO PIN 1 is used for TX/RX Control manual (no ATR)
+        // GPIO PIN 2-4 are used for Band Setting manual (no ATR)
+        // -> 0x0F is the mask , 0x0 -> manual (0x1 = ATR)
+        usrp->set_gpio_attr("FP0", "CTRL", 0x00, 0x0F);  
+        // setting Data DiRection 0x1 = output
+        usrp->set_gpio_attr("FP0", "DDR", 0x0f, 0x0F);
+        // reset GPIO pin 0,1,2,3
+        usrp->set_gpio_attr("FP0", "OUT", 0x00, 0x0F);
+        /*
+        std::cerr << "GPIO Ctrl: " << usrp->get_gpio_attr("FP0","CTRL") << std::endl;
+        std::cerr << "GPIO DDR : " << usrp->get_gpio_attr("FP0","DDR") << std::endl;
+        std::cerr << "GPIO OUT : " << usrp->get_gpio_attr("FP0","OUT") << std::endl;
+        */
+        
+        setTXOff();
+        break;
+        
+      default: //default runs the original code
+        //original code begin
+        std::vector<std::string> port = usrp->get_gpio_banks(0); 
 
-    // we set J400 pin 1 HIGH on transmit, LOW on RX.   
-    // this is becaus the "default" drive on the pins
-    // if the wrong fpga binary is loaded, the transmitter
-    // TR switch will be left in the TX position. 
-    // This may result in "no signal heard" but at least
-    // it is less likely to result in "blown up radio"
-    // Best configuratio, is to look at both pin 1 and pin 3
-    // TX is when 1 is HIGH and 3 is LOW
-    // RX is when 1 is LOW and 3 is HIGH
-    // do something safe when they are both HIGH or both LOW.
-    usrp->set_gpio_attr("FP0", "DDR", 0x300, 0x300);
-    usrp->set_gpio_attr("FP0", "CTRL", 0x0, 0x300);  
+        // we set J400 pin 1 HIGH on transmit, LOW on RX.   
+        // this is becaus the "default" drive on the pins
+        // if the wrong fpga binary is loaded, the transmitter
+        // TR switch will be left in the TX position. 
+        // This may result in "no signal heard" but at least
+        // it is less likely to result in "blown up radio"
+        // Best configuratio, is to look at both pin 1 and pin 3
+        // TX is when 1 is HIGH and 3 is LOW
+        // RX is when 1 is LOW and 3 is HIGH
+        // do something safe when they are both HIGH or both LOW.
+        usrp->set_gpio_attr("FP0", "DDR", 0x300, 0x300);
+        usrp->set_gpio_attr("FP0", "CTRL", 0x0, 0x300);  
 
-    setTXOff();
+        setTXOff();
+        //original code end
+    }
   }
 
   bool B200Control::setTXOn()
   {
-    usrp->set_gpio_attr("FP0", "OUT", 0x100, 0x300);
-    return true; 
+    std::cerr << "B200Control::setTXOn()" << std::endl;
+    
+    switch (B200Control::B200_type) {
+      case SoDa_B200_type_t::eB200mini : {
+        usrp->set_gpio_attr("FP0", "OUT", 0x1, 0x01);
+        break;
+        }
+      default :
+        //original code
+        usrp->set_gpio_attr("FP0", "OUT", 0x100, 0x300);
+    } 
+    return true; //original code
   }
 
   bool B200Control::setTXOff()
   {
-    usrp->set_gpio_attr("FP0", "OUT", 0x200, 0x300);
-    return true; 
-    return true; 
+    std::cerr << "B200Control::setTXOff()" << std::endl;
+
+    switch (B200Control::B200_type) {
+      case SoDa_B200_type_t::eB200mini : {
+        usrp->set_gpio_attr("FP0", "OUT", 0x00, 0x01);
+        break;        
+        }
+      default:
+        //original code
+        usrp->set_gpio_attr("FP0", "OUT", 0x200, 0x300);
+    }
+    return true; //original
+    //return true; // duplicate in original
   }
 
   bool B200Control::getTX()

--- a/src/B200Control.hxx
+++ b/src/B200Control.hxx
@@ -39,6 +39,27 @@
 
 
 namespace SoDa {
+  /**
+   * @brief B2xxy-z subtypes for simplified usage (DD0VS)
+   * 
+   * This is a workaraound, to integrate B200mini (Sept 2019) into 
+   * SoDaRadio.
+   * All specific action for B200/B210/B2xx are not carried out for
+   * B200mini.
+   * On specific places special care will be taken for B200mini only.
+   * In a first attempt TX/RX relay switching will be implemented via
+   * B200mini GPIO pin. Today (16th of Feb 2020, all versions of B2xx 
+   * have GPIOs). To avoid interferences with the original code only 
+   * B200mini specific actions will be carried, the others are kept
+   * functional.
+   */
+  typedef enum {
+    eB200,      // e = enum; B200 seems to be defined somewhere else
+    eB210,
+    eB200mini,
+    eB200mini_i,
+    eB205mini_i
+    } SoDa_B200_type_t;
   
   /**
    * @brief Transmit/Receive switch control for B200/B210 via the 
@@ -102,6 +123,8 @@ namespace SoDa {
     uhd::usrp::multi_usrp::sptr usrp; 
     
     int mboard; 
+    SoDa_B200_type_t B200_type;   //see comment above
+    std::string modelname;  //is redundant, but used for simpler programming
   };
 }
 #endif

--- a/src/TRControl.cxx
+++ b/src/TRControl.cxx
@@ -64,7 +64,8 @@ namespace SoDa {
 
     }
     else if ((modelname == std::string("B200")) || 
-	     (modelname == std::string("B210"))) {
+             (modelname == std::string("B210")) ||
+             (modelname == std::string("B200mini"))) {
       return new B200Control(usrp, mboard); 
     }
     else {

--- a/src/USRPCtrl.cxx
+++ b/src/USRPCtrl.cxx
@@ -53,7 +53,8 @@ const double SoDa::USRPCtrl::rxmode_offset = 1.0e6;
 
 SoDa::USRPCtrl * SoDa::USRPCtrl::singleton_ctrl_obj = NULL; 
 
-SoDa::USRPCtrl::USRPCtrl(Params * _params, CmdMBox * _cmd_stream) : SoDa::SoDaThread("USRPCtrl")
+
+SoDa::USRPCtrl::USRPCtrl(Params * _params) : SoDa::Thread("USRPCtrl")
 {
   // point to myself.... 
   SoDa::USRPCtrl::singleton_ctrl_obj = this;
@@ -76,17 +77,14 @@ SoDa::USRPCtrl::USRPCtrl(Params * _params, CmdMBox * _cmd_stream) : SoDa::SoDaTh
   tx_ant = std::string("TX");
   motherboard_name = std::string("UNKNOWN_MB");
   
-  cmd_stream = _cmd_stream;
   params = _params;
 
-  // subscribe to the command stream.
-  subid = cmd_stream->subscribe();
   
   // make the device.
   usrp = uhd::usrp::multi_usrp::make(params->getRadioArgs());
 
   if(usrp == NULL) {
-    throw SoDaException((boost::format("Unable to allocate USRP unit with arguments = [%]\n") % params->getRadioArgs()).str(), this);
+    throw SoDa::Exception((boost::format("Unable to allocate USRP unit with arguments = [%s]\n") % params->getRadioArgs()).str(), this);
   }
 
   // We need to find out if this is a B2xx or something like it -- they don't
@@ -94,7 +92,7 @@ SoDa::USRPCtrl::USRPCtrl(Params * _params, CmdMBox * _cmd_stream) : SoDa::SoDaTh
   PropTree tree(usrp, getObjName()); 
 
   motherboard_name = tree.getStringProp("name", "unknown");
-    
+
   if((motherboard_name == "B200") || (motherboard_name == "B210")) {
     // B2xx needs a master clock rate of 50 MHz to generate a sample rate of 625 kS/s.
     // B2xx needs a master clock rate of 25 MHz to generate a sample rate of 625 kS/s.
@@ -191,11 +189,37 @@ SoDa::USRPCtrl::USRPCtrl(Params * _params, CmdMBox * _cmd_stream) : SoDa::SoDaTh
 
   // if we are in integer-N mode, setup the step table.
   testIntNMode(params->forceIntN(), params->forceFracN()); 
+  
+  // we need a cmd stream
+  cmd_stream = NULL; 
+}
+
+/// implement the subscription method
+void SoDa::USRPCtrl::subscribeToMailBox(const std::string & mbox_name, 
+					SoDa::BaseMBox * mbox_p) {
+  if(mbox_name == "CMD") {
+    SoDa::CmdMBox * _cmd_stream = dynamic_cast<SoDa::CmdMBox *>(mbox_p);
+    if(_cmd_stream != NULL) {
+      cmd_stream = _cmd_stream;
+
+      // subscribe to the command stream.
+      subid = cmd_stream->subscribe();
+    }
+    else {
+      throw SoDa::Exception((boost::format("Bad mailbox pointer for mailbox named = [%s]\n") 
+			   % mbox_name).str() , this);	
+    }
+  }
 }
 
 
 void SoDa::USRPCtrl::run()
 {
+  if(cmd_stream == NULL) {
+      throw SoDa::Exception((boost::format("Never got command stream subscription\n")).str(), 
+			  this);	
+  }
+  
   uhd::set_thread_priority_safe(); 
   // now do the event loop.  we watch
   // for commands and responses on the command stream.


### PR DESCRIPTION
This implements TX/RX signal via GPIO for a B200mini. (Pin 0 of GPIO is High for TX, low for RX, pin 1,2,3 are reserved for band switches (only reservation implemented).